### PR TITLE
Fix bugs: Add duplicate m/ prefix validation and joinDate validation

### DIFF
--- a/src/main/java/seedu/tutorpal/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tutorpal/logic/commands/EditCommand.java
@@ -33,6 +33,7 @@ import seedu.tutorpal.model.person.Phone;
 import seedu.tutorpal.model.person.Role;
 import seedu.tutorpal.model.person.Student;
 import seedu.tutorpal.model.person.Tutor;
+import seedu.tutorpal.model.person.exceptions.InvalidRangeException;
 
 /**
  * Edits the details of an existing person in the address book.
@@ -141,6 +142,13 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Class> updatedClasses = editPersonDescriptor.getClasses().orElse(personToEdit.getClasses());
         JoinDate updatedJoinDate = editPersonDescriptor.getJoinDate().orElse(personToEdit.getJoinDate());
+
+        // Validate that new joinDate is not after existing payment history
+        try {
+            personToEdit.getPaymentHistory().validateJoinDate(updatedJoinDate);
+        } catch (InvalidRangeException e) {
+            throw new CommandException(e.getMessage());
+        }
 
         // Construct appropriate subtype; role is not editable per parser
         if (personToEdit.getRole() == Role.STUDENT) {

--- a/src/main/java/seedu/tutorpal/logic/parser/PaymentCommandParser.java
+++ b/src/main/java/seedu/tutorpal/logic/parser/PaymentCommandParser.java
@@ -33,6 +33,8 @@ public class PaymentCommandParser implements Parser<PaymentCommand> {
     public PaymentCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PAYMENT_MONTH);
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PAYMENT_MONTH);
+
         Index index = parseIndex(argMultimap);
         YearMonth month = parsePaymentMonth(argMultimap);
 

--- a/src/main/java/seedu/tutorpal/logic/parser/UnpayCommandParser.java
+++ b/src/main/java/seedu/tutorpal/logic/parser/UnpayCommandParser.java
@@ -33,6 +33,8 @@ public class UnpayCommandParser implements Parser<UnpayCommand> {
     public UnpayCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PAYMENT_MONTH);
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PAYMENT_MONTH);
+
         Index index = parseIndex(argMultimap);
         YearMonth month = parsePaymentMonth(argMultimap);
 

--- a/src/main/java/seedu/tutorpal/model/person/PaymentHistory.java
+++ b/src/main/java/seedu/tutorpal/model/person/PaymentHistory.java
@@ -185,6 +185,28 @@ public class PaymentHistory {
     public int hashCode() {
         return Objects.hash(joinDate, monthlyPayments);
     }
+    /**
+     * Validates that the new joinDate is not after any existing payment history entries.
+     * This ensures data integrity when updating a person's join date.
+     *
+     * @param newJoinDate The new join date to validate
+     * @throws seedu.tutorpal.model.person.exceptions.InvalidRangeException if the new joinDate is after existing
+     *         payment records
+     */
+    public void validateJoinDate(JoinDate newJoinDate) {
+        YearMonth newJoinMonth = newJoinDate.toYearMonth();
+
+        // Check if any existing payment records would be before the new join date
+        for (MonthlyPayment payment : monthlyPayments) {
+            if (payment.getMonth().isBefore(newJoinMonth)) {
+                throw new seedu.tutorpal.model.person.exceptions.InvalidRangeException(
+                    String.format("Cannot set join date to %s as there are existing payment records "
+                        + "before this date. Earliest payment record: %s",
+                        newJoinDate.toString(), payment.getMonth()));
+            }
+        }
+    }
+
     @Override
     public String toString() {
         return "PaymentHistory{"


### PR DESCRIPTION
- Add duplicate prefix validation for m/ in PaymentCommandParser and UnpayCommandParser to prevent users from accidentally entering multiple month values

- Add joinDate validation in EditCommand to prevent setting joinDate after existing payment history records, ensuring data integrity

Fixes #172 